### PR TITLE
Quality-of-life ideas for the appearance editor

### DIFF
--- a/components/modals/AppearanceModal.tsx
+++ b/components/modals/AppearanceModal.tsx
@@ -25,7 +25,7 @@ export function AppearanceModal() {
   const [lastDrawingPosition, setLastDrawingPosition] = useState({ x: 0, y: 0 })
   const [selectedColor, setSelectedColor] = useState('#000000')
   const [tool, setTool] = useState<'brush' | 'paintBucket' | 'eraser' | 'line'>(
-    'line'
+    'brush'
   )
   const [brushSize, setBrushSize] = useState(3)
   const canvasRef = useRef<HTMLCanvasElement>(null)
@@ -290,7 +290,7 @@ export function AppearanceModal() {
     ctx.globalAlpha = 0.2
 
     const { x, y } = getCanvasCoordinates(e)
-    if (tool === 'brush' || tool === 'eraser') {
+    if (tool === 'brush' || tool === 'eraser' || tool === 'line') {
       const offset = Math.floor(brushSize / 2)
       ctx.fillRect(x - offset, y - offset, brushSize, brushSize)
     } else {
@@ -351,13 +351,15 @@ export function AppearanceModal() {
 
   // Gemeinsame Logik für das Beenden des Zeichnens.
   const handleEnd = (
-    e: React.MouseEvent<HTMLCanvasElement> | React.TouchEvent<HTMLCanvasElement>
+    e: React.MouseEvent<HTMLCanvasElement> | React.TouchEvent<HTMLCanvasElement>,
+    clear: boolean
   ) => {
     e.preventDefault()
     endDraw(e)
     setIsDrawing(false)
     hasPushedUndo.current = false
-    clearPreview()
+    if (clear) clearPreview();
+    else updatePreview(e)
   }
 
   // Spezifische Wrapper für Touch-Events.
@@ -368,7 +370,7 @@ export function AppearanceModal() {
     handleMove(e)
   }
   const handleTouchEnd = (e: React.TouchEvent<HTMLCanvasElement>) => {
-    handleEnd(e)
+    handleEnd(e, true)
   }
 
   // Maus-Handler.
@@ -378,8 +380,12 @@ export function AppearanceModal() {
   const handleMouseMove = (e: React.MouseEvent<HTMLCanvasElement>) => {
     handleMove(e)
   }
-  const handleMouseUpOrLeave = (e: React.MouseEvent<HTMLCanvasElement>) => {
-    handleEnd(e)
+  const handleMouseUp = (e: React.MouseEvent<HTMLCanvasElement>) => {
+    handleEnd(e, false)
+  }
+
+  const handleMouseLeave = (e: React.MouseEvent<HTMLCanvasElement>) => {
+    handleEnd(e, true);
   }
 
   // Undo: stellt den letzten Zustand wieder her.
@@ -767,8 +773,8 @@ export function AppearanceModal() {
                     }}
                     onMouseDown={handleMouseDown}
                     onMouseMove={handleMouseMove}
-                    onMouseUp={handleMouseUpOrLeave}
-                    onMouseLeave={handleMouseUpOrLeave}
+                    onMouseUp={handleMouseUp}
+                    onMouseLeave={handleMouseLeave}
                     onTouchStart={handleTouchStart}
                     onTouchMove={handleTouchMove}
                     onTouchEnd={handleTouchEnd}

--- a/components/modals/AppearanceModal.tsx
+++ b/components/modals/AppearanceModal.tsx
@@ -212,6 +212,21 @@ export function AppearanceModal() {
       ctx.fillRect(x, y, 1, 1)
     }
     ctx.globalAlpha = 1.0
+
+    /**
+     * Show sprite boundary while drawing.
+     * This should make it easier to keep 'inside the lines'
+     */
+    ctx.save();
+    ctx.globalAlpha = 0.2
+    ctx.fillStyle = 'black';
+    const panelWidth = overlayCanvas.width / 4;
+    for (let i = 0; i < 4; i++) {
+      const { x, y } = getCanvasCoordinates(e);
+      if (x < i * panelWidth || x >= (i+1) * panelWidth)
+        ctx.fillRect(i * panelWidth, 0, panelWidth, overlayCanvas.height);
+    }
+    ctx.restore();
   }
 
   const clearPreview = () => {

--- a/components/modals/AppearanceModal.tsx
+++ b/components/modals/AppearanceModal.tsx
@@ -22,9 +22,11 @@ import { karolDefaultImage } from '../../lib/data/images'
 export function AppearanceModal() {
   const [count, setCount] = useState(0)
   const [isDrawing, setIsDrawing] = useState(false)
-  const [lastDrawingPosition, setLastDrawingPosition] = useState({x: 0, y: 0});
+  const [lastDrawingPosition, setLastDrawingPosition] = useState({ x: 0, y: 0 })
   const [selectedColor, setSelectedColor] = useState('#000000')
-  const [tool, setTool] = useState<'brush' | 'paintBucket' | 'eraser' | 'line'>('line')
+  const [tool, setTool] = useState<'brush' | 'paintBucket' | 'eraser' | 'line'>(
+    'line'
+  )
   const [brushSize, setBrushSize] = useState(3)
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const previewCanvasRef = useRef<HTMLCanvasElement>(null)
@@ -175,27 +177,27 @@ export function AppearanceModal() {
   }
 
   const drawLineTo = (
-    ctx: CanvasRenderingContext2D, 
-    toolCall: (ctx: CanvasRenderingContext2D, x: number, y: number) => void, 
-    from: {x: number, y: number}, 
-    to: {x: number, y:number}, 
+    ctx: CanvasRenderingContext2D,
+    toolCall: (ctx: CanvasRenderingContext2D, x: number, y: number) => void,
+    from: { x: number; y: number },
+    to: { x: number; y: number },
     offset: number
   ) => {
-    ctx.save();
-    const distance = Math.sqrt((to.x - from.x)**2 + (to.y - from.y)**2) // a global distance function might be useful
+    ctx.save()
+    const distance = Math.sqrt((to.x - from.x) ** 2 + (to.y - from.y) ** 2) // a global distance function might be useful
     // interpolating between last and current position as to avoid gaps
     // moveTo and lineTo do not work here because of anti-aliasing
-    let stepSize = 1; // looks the best
+    let stepSize = 1 // looks the best
     for (let d = 0; d < distance; d += stepSize) {
       toolCall(
         // vector normalization could also be a global function
         ctx,
-        Math.round(from.x + d * (to.x - from.x) / distance - offset), 
-        Math.round(from.y + d * (to.y - from.y) / distance - offset), 
+        Math.round(from.x + (d * (to.x - from.x)) / distance - offset),
+        Math.round(from.y + (d * (to.y - from.y)) / distance - offset)
       )
     }
-    toolCall(ctx, to.x - offset, to.y - offset);
-    ctx.restore();
+    toolCall(ctx, to.x - offset, to.y - offset)
+    ctx.restore()
   }
 
   // Zeichnen für Pinsel, Linie und Radiergummi.
@@ -208,14 +210,16 @@ export function AppearanceModal() {
 
     const { x, y } = getCanvasCoordinates(e)
     const offset = Math.floor(brushSize / 2)
-    
-    let toolCall: (ctx: CanvasRenderingContext2D, x: number, y:number) => void;
+
+    let toolCall: (ctx: CanvasRenderingContext2D, x: number, y: number) => void
     if (tool === 'eraser') {
       // Beim Radiergummi werden Pixel gelöscht (transparent gemacht).
-      toolCall = (ctx: CanvasRenderingContext2D, x: number, y: number) => ctx.clearRect(x, y, brushSize, brushSize);
+      toolCall = (ctx: CanvasRenderingContext2D, x: number, y: number) =>
+        ctx.clearRect(x, y, brushSize, brushSize)
     } else {
       ctx.fillStyle = selectedColor
-      toolCall = (ctx: CanvasRenderingContext2D, x: number, y: number) => ctx.fillRect(x, y, brushSize, brushSize);
+      toolCall = (ctx: CanvasRenderingContext2D, x: number, y: number) =>
+        ctx.fillRect(x, y, brushSize, brushSize)
     }
 
     if (tool === 'line') {
@@ -225,24 +229,24 @@ export function AppearanceModal() {
         const previewCtx = previewCanvas?.getContext('2d')
         if (!previewCtx || !canvas) return
 
-        previewCtx.save(); // for safety
-        previewCtx.fillStyle = selectedColor;
-        drawLineTo(previewCtx, toolCall, lastDrawingPosition, {x, y}, offset);
-        previewCtx.restore();
+        previewCtx.save() // for safety
+        previewCtx.fillStyle = selectedColor
+        drawLineTo(previewCtx, toolCall, lastDrawingPosition, { x, y }, offset)
+        previewCtx.restore()
       } else {
         // only store this at the start of a new line!
-        setLastDrawingPosition({x, y});
+        setLastDrawingPosition({ x, y })
       }
     } else {
       if (isDrawing) {
-        drawLineTo(ctx, toolCall, lastDrawingPosition, {x, y}, offset);
+        drawLineTo(ctx, toolCall, lastDrawingPosition, { x, y }, offset)
       }
       // always draw at least one point
-      ctx.save();
-      toolCall(ctx, x - offset, y - offset);
-      ctx.restore();
+      ctx.save()
+      toolCall(ctx, x - offset, y - offset)
+      ctx.restore()
       // store the last drawing position
-      setLastDrawingPosition({x, y}); // is that how you use React?
+      setLastDrawingPosition({ x, y }) // is that how you use React?
     }
 
     updateImageDataUrl(canvas)
@@ -259,16 +263,17 @@ export function AppearanceModal() {
     const { x, y } = getCanvasCoordinates(e)
     const offset = Math.floor(brushSize / 2)
 
-    let toolCall = (ctx: CanvasRenderingContext2D, x: number, y: number) => ctx.fillRect(x, y, brushSize, brushSize);
+    let toolCall = (ctx: CanvasRenderingContext2D, x: number, y: number) =>
+      ctx.fillRect(x, y, brushSize, brushSize)
 
-    ctx.save(); // for safety
+    ctx.save() // for safety
     ctx.fillStyle = selectedColor
     if (tool === 'line' && isDrawing) {
       // complete the line
-      drawLineTo(ctx, toolCall, lastDrawingPosition, {x, y}, offset);
-      setLastDrawingPosition({x, y});
+      drawLineTo(ctx, toolCall, lastDrawingPosition, { x, y }, offset)
+      setLastDrawingPosition({ x, y })
     }
-    ctx.restore();
+    ctx.restore()
   }
 
   // Aktualisiert die Vorschau-Leinwand mit einer gestrichelten Umrandung.
@@ -295,15 +300,15 @@ export function AppearanceModal() {
 
     // Show sprite boundary while drawing.
     // This should make it easier to keep 'inside the lines'
-    ctx.save();
+    ctx.save()
     ctx.globalAlpha = 0.2
-    ctx.fillStyle = 'black';
-    const panelWidth = overlayCanvas.width / 4;
+    ctx.fillStyle = 'black'
+    const panelWidth = overlayCanvas.width / 4
     for (let i = 0; i < 4; i++) {
-      if (x < i * panelWidth || x >= (i+1) * panelWidth)
-        ctx.fillRect(i * panelWidth, 0, panelWidth, overlayCanvas.height);
+      if (x < i * panelWidth || x >= (i + 1) * panelWidth)
+        ctx.fillRect(i * panelWidth, 0, panelWidth, overlayCanvas.height)
     }
-    ctx.restore();
+    ctx.restore()
   }
 
   const clearPreview = () => {
@@ -349,7 +354,7 @@ export function AppearanceModal() {
     e: React.MouseEvent<HTMLCanvasElement> | React.TouchEvent<HTMLCanvasElement>
   ) => {
     e.preventDefault()
-    endDraw(e);
+    endDraw(e)
     setIsDrawing(false)
     hasPushedUndo.current = false
     clearPreview()
@@ -514,7 +519,8 @@ export function AppearanceModal() {
               />
             </div>
             <div className="flex flex-wrap justify-center gap-3 mt-3">
-              <button title='Pinsel'
+              <button
+                title="Pinsel"
                 className={`px-3 py-1 border rounded ${
                   tool === 'brush' ? 'bg-gray-300' : 'bg-white'
                 }`}
@@ -525,7 +531,8 @@ export function AppearanceModal() {
               >
                 <FaIcon icon={faPaintBrush} />
               </button>
-              <button title='Füllen'
+              <button
+                title="Füllen"
                 className={`px-3 py-1 border rounded ${
                   tool === 'paintBucket' ? 'bg-gray-300' : 'bg-white'
                 }`}
@@ -536,7 +543,8 @@ export function AppearanceModal() {
               >
                 <FaIcon icon={faFillDrip} />
               </button>
-              <button title='Linie'
+              <button
+                title="Linie"
                 className={`px-3 py-1 border rounded ${
                   tool === 'line' ? 'bg-gray-300' : 'bg-white'
                 }`}
@@ -545,9 +553,20 @@ export function AppearanceModal() {
                   setTool('line')
                 }}
               >
-                <FaIcon icon={faLinesLeaning} />
+                <svg width="18" height="18" viewBox="0 0 14 14">
+                  <line
+                    x1="2"
+                    y1="12"
+                    x2="12"
+                    y2="2"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                  />
+                </svg>
               </button>
-              <button title='Radierer'
+              <button
+                title="Radierer"
                 className={`px-3 py-1 border rounded ${
                   tool === 'eraser' ? 'bg-gray-300' : 'bg-white'
                 }`}
@@ -558,7 +577,8 @@ export function AppearanceModal() {
               >
                 <FaIcon icon={faEraser} />
               </button>
-              <button title='Rückgängig'
+              <button
+                title="Rückgängig"
                 className="px-3 py-1 bg-purple-200 hover:bg-purple-300 rounded"
                 onClick={handleUndo}
               >

--- a/components/modals/AppearanceModal.tsx
+++ b/components/modals/AppearanceModal.tsx
@@ -225,8 +225,10 @@ export function AppearanceModal() {
         const previewCtx = previewCanvas?.getContext('2d')
         if (!previewCtx || !canvas) return
 
+        previewCtx.save(); // for safety
         previewCtx.fillStyle = selectedColor;
         drawLineTo(previewCtx, toolCall, lastDrawingPosition, {x, y}, offset);
+        previewCtx.restore();
       } else {
         // only store this at the start of a new line!
         setLastDrawingPosition({x, y});
@@ -236,8 +238,9 @@ export function AppearanceModal() {
         drawLineTo(ctx, toolCall, lastDrawingPosition, {x, y}, offset);
       }
       // always draw at least one point
+      ctx.save();
       toolCall(ctx, x - offset, y - offset);
-
+      ctx.restore();
       // store the last drawing position
       setLastDrawingPosition({x, y}); // is that how you use React?
     }
@@ -256,14 +259,16 @@ export function AppearanceModal() {
     const { x, y } = getCanvasCoordinates(e)
     const offset = Math.floor(brushSize / 2)
 
-    ctx.fillStyle = selectedColor
     let toolCall = (ctx: CanvasRenderingContext2D, x: number, y: number) => ctx.fillRect(x, y, brushSize, brushSize);
 
+    ctx.save(); // for safety
+    ctx.fillStyle = selectedColor
     if (tool === 'line' && isDrawing) {
       // complete the line
       drawLineTo(ctx, toolCall, lastDrawingPosition, {x, y}, offset);
       setLastDrawingPosition({x, y});
     }
+    ctx.restore();
   }
 
   // Aktualisiert die Vorschau-Leinwand mit einer gestrichelten Umrandung.
@@ -278,26 +283,23 @@ export function AppearanceModal() {
 
     ctx.clearRect(0, 0, overlayCanvas.width, overlayCanvas.height)
     ctx.globalAlpha = 0.2
+
+    const { x, y } = getCanvasCoordinates(e)
     if (tool === 'brush' || tool === 'eraser') {
-      const { x, y } = getCanvasCoordinates(e)
       const offset = Math.floor(brushSize / 2)
       ctx.fillRect(x - offset, y - offset, brushSize, brushSize)
     } else {
-      const { x, y } = getCanvasCoordinates(e)
       ctx.fillRect(x, y, 1, 1)
     }
     ctx.globalAlpha = 1.0
 
-    /**
-     * Show sprite boundary while drawing.
-     * This should make it easier to keep 'inside the lines'
-     */
+    // Show sprite boundary while drawing.
+    // This should make it easier to keep 'inside the lines'
     ctx.save();
     ctx.globalAlpha = 0.2
     ctx.fillStyle = 'black';
     const panelWidth = overlayCanvas.width / 4;
     for (let i = 0; i < 4; i++) {
-      const { x, y } = getCanvasCoordinates(e);
       if (x < i * panelWidth || x >= (i+1) * panelWidth)
         ctx.fillRect(i * panelWidth, 0, panelWidth, overlayCanvas.height);
     }


### PR DESCRIPTION
This PR adds
* A faint shadow over the 'inactive' sprites to make it easier to see what is part of the current sprite and what isn't. f33178cf9dee37c9624419a97ec40487de082bea
* Line interpolation for the brush and eraser, such that gaps are prevented when drawing fast. This solution doesn't use moveTo or lineTo to avoid anti-aliasing 9f91550598894130e2ce9200f033ba33ed88abbc
* A line tool that uses the preview layer to show where the line will end up before drawing it onto the canvas 579a82706cd62194fb987bc2fae857c0f6173920
* Added titles to some of the buttons
* Some saving and restoring, could probably be removed 9fde4188f0eb18f0412feff1ef119969d787e359

Box or circle tools could be implemented similarly to 579a82706cd62194fb987bc2fae857c0f6173920 relatively easily.